### PR TITLE
Fix: Gulp Screenshot plugin options

### DIFF
--- a/lib/gulp/screenshots/index.js
+++ b/lib/gulp/screenshots/index.js
@@ -14,13 +14,14 @@ const DEFAULT_OPTIONS = {
   server: {
     public: 'dist',
   },
+  exclude: page => page.screenshot === false,
 };
 
 module.exports = options => {
   options = defaultsDeep(options, DEFAULT_OPTIONS);
   return through.obj(async function(file, enc, cb) {
     const page = file.data && file.data.page;
-    if (!file.contents || (page && (page.screenshot === false || page.menu === false))) {
+    if (!file.contents || (page && options.exclude(page))) {
       cb();
       return;
     }

--- a/lib/gulp/screenshots/index.js
+++ b/lib/gulp/screenshots/index.js
@@ -7,8 +7,8 @@ const capture = require('./capture');
 
 const DEFAULT_OPTIONS = {
   viewport: {
-    width: 1200,
-    height: 600,
+    width: 1000,
+    height: 750,
     deviceScaleFactor: 1,
   },
   server: {

--- a/lib/gulp/screenshots/index.js
+++ b/lib/gulp/screenshots/index.js
@@ -1,27 +1,26 @@
-const through = require('through2');
 const http = require('http');
+const defaultsDeep = require('lodash.defaultsdeep');
 const puppeteer = require('puppeteer');
 const handle = require('serve-handler');
+const through = require('through2');
 const capture = require('./capture');
 
-module.exports = (
-  options = {
-    viewport: {
-      width: 1200,
-      height: 600,
-      deviceScaleFactor: 1,
-    },
-    server: {
-      public: 'dist',
-    },
+const DEFAULT_OPTIONS = {
+  viewport: {
+    width: 1200,
+    height: 600,
+    deviceScaleFactor: 1,
   },
-) =>
-  through.obj(async function(file, enc, cb) {
+  server: {
+    public: 'dist',
+  },
+};
+
+module.exports = options => {
+  options = defaultsDeep(options, DEFAULT_OPTIONS);
+  return through.obj(async function(file, enc, cb) {
     const page = file.data && file.data.page;
-    if (
-      !file.contents ||
-      (page && (page.screenshot === false || page.menu === false))
-    ) {
+    if (!file.contents || (page && (page.screenshot === false || page.menu === false))) {
       cb();
       return;
     }
@@ -40,6 +39,7 @@ module.exports = (
 
     cb();
   });
+};
 
 function startServer(config) {
   return http.createServer((req, resp) => handle(req, resp, config)).listen(0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4153,6 +4153,11 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.defaultsdeep": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA=="
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
   "dependencies": {
     "front-matter": "^3.0.2",
     "js-yaml": "^3.13.1",
+    "lodash.defaultsdeep": "^4.6.1",
     "mississippi": "^4.0.0",
-    "vinyl-fs": "^3.0.3",
     "puppeteer": "^2.1.1",
     "serve-handler": "^6.1.2",
     "through2": "^3.0.1",
-    "vinyl": "^2.2.0"
+    "vinyl": "^2.2.0",
+    "vinyl-fs": "^3.0.3"
   },
   "devDependencies": {
     "@ava/babel": "^1.0.0",


### PR DESCRIPTION
- Gulp Screenshot: Fix bug preventing default options from merging properly with overrides (uses [lodash.defaultsdeep](https://www.npmjs.com/package/lodash.defaultsdeep))
- Gulp Screenshot: Update default value viewport dimensions
- Gulp Screenshot: Expose exclusion logic to clients via `exclude` option