### PR TITLE
Expose additional Puppeteer options for configuring screenshots

### DIFF
--- a/lib/gulp/screenshots/README.md
+++ b/lib/gulp/screenshots/README.md
@@ -1,0 +1,40 @@
+# Gulp Screenshots Plugin
+
+> Capture page screenshots with Puppeteer
+
+## Usage
+
+```js
+const { src, dest } = require('gulp');
+const gulpScreenshots = require('@upstatement/puppy/lib/gulp/screenshots')
+
+const capture = async function() =>
+  src('./*.html')
+    .pipe(gulpScreenshots({
+        // Global options for `Page.setViewport()`
+        // https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagesetviewportviewport
+        viewport: {
+          width: 1400,
+          height: 1000,
+          deviceScaleFactor: 0.75,
+        },
+        // Global options for `Page.goto()
+        // https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagegotourl-options
+        goto: {
+            waitUntil: 'networkidle2',
+        },
+        // Global options for `Page.screenshot()
+        // https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagescreenshotoptions
+        screenshot: {
+            type: 'png',
+        }
+      },
+      // Function resolving page-specific capture options
+      pageCaptureOptions: page => page.thumbnail,
+      // Function to filter out pages that should not get screenshots
+      exclude: page => !page.thumbnail || !page.thumbnail.match(/auto/i),
+    });
+    .pipe(dest('./screenshots))
+};
+
+```

--- a/lib/gulp/screenshots/capture.js
+++ b/lib/gulp/screenshots/capture.js
@@ -5,17 +5,17 @@ const Vinyl = require('vinyl');
  *
  * @return Vinyl
  */
-module.exports = async ({ file, browser, baseUrl, viewport }) => {
+module.exports = async ({ file, browser, baseUrl, options }) => {
   const page = await browser.newPage();
-  await page.setViewport(viewport);
+  await page.setViewport(options.viewport);
 
   const url = `${baseUrl}/${file.relative}`;
-  await page.goto(url);
-  const screenshot = await page.screenshot();
+  await page.goto(url, options.goto);
+  const screenshot = await page.screenshot({ ...options.screenshot, encoding: 'binary' });
 
   return new Vinyl({
     cwd: file.cwd,
-    path: `${file.relative}.png`,
+    path: `${file.relative}.${options.screenshot.type}`,
     contents: screenshot,
   });
 };

--- a/lib/gulp/screenshots/index.js
+++ b/lib/gulp/screenshots/index.js
@@ -11,9 +11,16 @@ const DEFAULT_OPTIONS = {
     height: 750,
     deviceScaleFactor: 1,
   },
+  goto: {
+    waitUntil: 'networkidle2',
+  },
+  screenshot: {
+    type: 'png',
+  },
   server: {
     public: 'dist',
   },
+  pageCaptureOptions: page => page.screenshot,
   exclude: page => page.screenshot === false,
 };
 
@@ -31,7 +38,12 @@ module.exports = options => {
     const { port } = server.address();
     const baseUrl = `http://127.0.0.1:${port}`;
 
-    const image = await capture({ file, baseUrl, browser, viewport: options.viewport });
+    const image = await capture({
+      file,
+      baseUrl,
+      browser,
+      options: setupPageCaptureOptions(page, options),
+    });
 
     this.push(image);
 
@@ -48,4 +60,19 @@ function startServer(config) {
 
 function startBrowser() {
   return puppeteer.launch({ headless: true });
+}
+
+function setupPageCaptureOptions(page, pluginOptions) {
+  const captureOptions = {
+    viewport: pluginOptions.viewport,
+    goto: pluginOptions.goto,
+    screenshot: pluginOptions.screenshot,
+  };
+  const pageOptions =
+    typeof pluginOptions.pageCaptureOptions === 'function' &&
+    pluginOptions.pageCaptureOptions(page);
+  if (pageOptions && typeof pageOptions === 'object') {
+    return defaultsDeep(pageOptions, captureOptions);
+  }
+  return captureOptions;
 }


### PR DESCRIPTION
- Exposes arguments to [`Page.setViewport()`](https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagesetviewportviewport)
- Exposes arguments to [`Page.goto()`](https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagegotourl-options)
- Exposes arguments to [`Page.screenshot()`](https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagescreenshotoptions)
- Exposes a function to provide page-specific overrides for all capture options