### PR TITLE
Gulp screenshots enhancements

### DIFF
--- a/lib/gulp/screenshots/capture.js
+++ b/lib/gulp/screenshots/capture.js
@@ -3,11 +3,11 @@ const Vinyl = require('vinyl');
 /**
  * Capture screenshot with Puppeteer.
  *
- * @param {Object} captureParams
+ * @param {object} captureParams
  * @param {Buffer} captureParams.file Buffer for the current file
- * @param {Object} captureParams.browserPage Puppeteer Page object https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-class-page
- * @param {String} captureParams.baseUrl Local server base URL
- * @param {Object} captureParams.options Page capture options
+ * @param {object} captureParams.browserPage Puppeteer Page object https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-class-page
+ * @param {string} captureParams.baseUrl Local server base URL
+ * @param {object} captureParams.options Page capture options
  *
  * @return {Vinyl}
  */

--- a/lib/gulp/screenshots/capture.js
+++ b/lib/gulp/screenshots/capture.js
@@ -5,13 +5,16 @@ const Vinyl = require('vinyl');
  *
  * @return Vinyl
  */
-module.exports = async ({ file, browser, baseUrl, options }) => {
-  const page = await browser.newPage();
-  await page.setViewport(options.viewport);
+module.exports = async ({ file, browserPage, baseUrl, options }) => {
+  await browserPage.setViewport(options.viewport);
 
   const url = `${baseUrl}/${file.relative}`;
-  await page.goto(url, options.goto);
-  const screenshot = await page.screenshot({ ...options.screenshot, encoding: 'binary' });
+  await browserPage.goto(url, options.goto);
+
+  const screenshot = await browserPage.screenshot({
+    ...options.screenshot,
+    encoding: 'binary'
+  });
 
   return new Vinyl({
     cwd: file.cwd,

--- a/lib/gulp/screenshots/capture.js
+++ b/lib/gulp/screenshots/capture.js
@@ -3,7 +3,13 @@ const Vinyl = require('vinyl');
 /**
  * Capture screenshot with Puppeteer.
  *
- * @return Vinyl
+ * @param {Object} captureParams
+ * @param {Buffer} captureParams.file Buffer for the current file
+ * @param {Object} captureParams.browserPage Puppeteer Page object https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-class-page
+ * @param {String} captureParams.baseUrl Local server base URL
+ * @param {Object} captureParams.options Page capture options
+ *
+ * @return {Vinyl}
  */
 module.exports = async ({ file, browserPage, baseUrl, options }) => {
   await browserPage.setViewport(options.viewport);
@@ -16,6 +22,7 @@ module.exports = async ({ file, browserPage, baseUrl, options }) => {
     encoding: 'binary'
   });
 
+  // https://github.com/gulpjs/vinyl#readme
   return new Vinyl({
     cwd: file.cwd,
     path: `${file.relative}.${options.screenshot.type}`,

--- a/lib/gulp/screenshots/index.js
+++ b/lib/gulp/screenshots/index.js
@@ -15,7 +15,7 @@ const DEFAULT_OPTIONS = {
     waitUntil: 'networkidle2',
   },
   screenshot: {
-    type: 'jpg',
+    type: 'jpeg',
   },
   server: {
     public: 'dist',
@@ -24,14 +24,48 @@ const DEFAULT_OPTIONS = {
   exclude: page => page.screenshot === false,
 };
 
-module.exports = async options => {
+function setupPageCaptureOptions(page, pluginOptions) {
+  const captureOptions = {
+    viewport: pluginOptions.viewport,
+    goto: pluginOptions.goto,
+    screenshot: pluginOptions.screenshot,
+  };
+
+  const pageOptions =
+    typeof pluginOptions.pageCaptureOptions === 'function' &&
+    pluginOptions.pageCaptureOptions(page);
+
+  if (pageOptions && typeof pageOptions === 'object') {
+    return defaultsDeep(pageOptions, captureOptions);
+  }
+
+  return captureOptions;
+}
+
+function startServer(config) {
+  return http.createServer((req, resp) => handle(req, resp, config)).listen(0);
+}
+
+function startBrowser() {
+  return puppeteer.launch({ headless: true });
+}
+
+module.exports = options => {
   options = defaultsDeep(options, DEFAULT_OPTIONS);
 
-  const server = startServer(options.server);
-  const browser = await startBrowser();
-  const browserPage = await browser.newPage();
+  let streamStarted = false;
+  let server;
+  let browser;
+  let browserPage;
 
-  return through.obj(async function(file, enc, cb) {
+  const stream = through.obj(async function(file, enc, cb) {
+    if (!streamStarted) {
+      server = startServer(options.server);
+      browser = await startBrowser();
+      browserPage = await browser.newPage();
+      streamStarted = true;
+    }
+
     const page = file.data && file.data.page;
 
     if (!file.contents || (page && options.exclude(page))) {
@@ -58,32 +92,12 @@ module.exports = async options => {
     } catch (e) {
       console.error(`Error in gulpScreenshots: ${e}`);
     }
+  });
 
-  }).on('finish', async () => {
+  stream.on('finish', async () => {
     await browser.close();
     await server.close();
   });
+
+  return stream;
 };
-
-function startServer(config) {
-  return http.createServer((req, resp) => handle(req, resp, config)).listen(0);
-}
-
-function startBrowser() {
-  return puppeteer.launch({ headless: true });
-}
-
-function setupPageCaptureOptions(page, pluginOptions) {
-  const captureOptions = {
-    viewport: pluginOptions.viewport,
-    goto: pluginOptions.goto,
-    screenshot: pluginOptions.screenshot,
-  };
-  const pageOptions =
-    typeof pluginOptions.pageCaptureOptions === 'function' &&
-    pluginOptions.pageCaptureOptions(page);
-  if (pageOptions && typeof pageOptions === 'object') {
-    return defaultsDeep(pageOptions, captureOptions);
-  }
-  return captureOptions;
-}

--- a/lib/gulp/screenshots/index.js
+++ b/lib/gulp/screenshots/index.js
@@ -27,10 +27,10 @@ const DEFAULT_OPTIONS = {
 /**
  * Get the screenshot options for each page
  *
- * @param {Object} page Puppy page data (path, title, description, thumbnail, other front-matter)
- * @param {Object} pluginOptions Options to override default puppeteer options
+ * @param {object} page Puppy page data (path, title, description, thumbnail, other front-matter)
+ * @param {object} pluginOptions Options to override default puppeteer options
  *
- * @returns {Object}
+ * @returns {object}
  */
 function setupPageCaptureOptions(page, pluginOptions) {
   const captureOptions = {
@@ -55,7 +55,7 @@ function setupPageCaptureOptions(page, pluginOptions) {
  *
  * @see https://nodejs.org/api/http.html#http_http_createserver_options_requestlistener
  *
- * @returns {Promise}
+ * @returns {http.Server}
  */
 function startServer(config) {
   return http.createServer((req, resp) => handle(req, resp, config)).listen(0);
@@ -73,7 +73,7 @@ function startBrowser() {
 /**
  * Gulp Screenshots plugin
  *
- * @param {Object} options Puppeteer config options
+ * @param {object} options Puppeteer config options
  *
  * @returns {Stream} Stream to pipe back into Gulp pipeline
  */

--- a/lib/gulp/screenshots/index.js
+++ b/lib/gulp/screenshots/index.js
@@ -15,7 +15,7 @@ const DEFAULT_OPTIONS = {
     waitUntil: 'networkidle2',
   },
   screenshot: {
-    type: 'png',
+    type: 'jpg',
   },
   server: {
     public: 'dist',
@@ -24,33 +24,44 @@ const DEFAULT_OPTIONS = {
   exclude: page => page.screenshot === false,
 };
 
-module.exports = options => {
+module.exports = async options => {
   options = defaultsDeep(options, DEFAULT_OPTIONS);
+
+  const server = startServer(options.server);
+  const browser = await startBrowser();
+  const browserPage = await browser.newPage();
+
   return through.obj(async function(file, enc, cb) {
     const page = file.data && file.data.page;
+
     if (!file.contents || (page && options.exclude(page))) {
       cb();
       return;
     }
-    const server = startServer(options.server);
-    const browser = await startBrowser();
 
     const { port } = server.address();
     const baseUrl = `http://127.0.0.1:${port}`;
 
-    const image = await capture({
-      file,
-      baseUrl,
-      browser,
-      options: setupPageCaptureOptions(page, options),
-    });
+    try {
+      const image = await capture({
+        file,
+        baseUrl,
+        browserPage,
+        options: setupPageCaptureOptions(page, options),
+      });
 
-    this.push(image);
+      // Push image to stream
+      this.push(image);
 
-    browser.close();
-    server.close();
+      cb();
 
-    cb();
+    } catch (e) {
+      console.error(`Error in gulpScreenshots: ${e}`);
+    }
+
+  }).on('finish', async () => {
+    await browser.close();
+    await server.close();
   });
 };
 

--- a/lib/gulp/screenshots/index.js
+++ b/lib/gulp/screenshots/index.js
@@ -24,6 +24,14 @@ const DEFAULT_OPTIONS = {
   exclude: page => page.screenshot === false,
 };
 
+/**
+ * Get the screenshot options for each page
+ *
+ * @param {Object} page Puppy page data (path, title, description, thumbnail, other front-matter)
+ * @param {Object} pluginOptions Options to override default puppeteer options
+ *
+ * @returns {Object}
+ */
 function setupPageCaptureOptions(page, pluginOptions) {
   const captureOptions = {
     viewport: pluginOptions.viewport,
@@ -42,14 +50,33 @@ function setupPageCaptureOptions(page, pluginOptions) {
   return captureOptions;
 }
 
+/**
+ * Start the server to visit in the headless Chrome instance
+ *
+ * @see https://nodejs.org/api/http.html#http_http_createserver_options_requestlistener
+ *
+ * @returns {Promise}
+ */
 function startServer(config) {
   return http.createServer((req, resp) => handle(req, resp, config)).listen(0);
 }
 
+/**
+ * Launch a headless Chrome instance
+ *
+ * @returns {Promise}
+ */
 function startBrowser() {
   return puppeteer.launch({ headless: true });
 }
 
+/**
+ * Gulp Screenshots plugin
+ *
+ * @param {Object} options Puppeteer config options
+ *
+ * @returns {Stream} Stream to pipe back into Gulp pipeline
+ */
 module.exports = options => {
   options = defaultsDeep(options, DEFAULT_OPTIONS);
 
@@ -59,11 +86,17 @@ module.exports = options => {
   let browserPage;
 
   const stream = through.obj(async function(file, enc, cb) {
-    if (!streamStarted) {
-      server = startServer(options.server);
-      browser = await startBrowser();
-      browserPage = await browser.newPage();
-      streamStarted = true;
+
+    try {
+      // Only start the server & browser once
+      if (!streamStarted) {
+        server = startServer(options.server);
+        browser = await startBrowser();
+        browserPage = await browser.newPage();
+        streamStarted = true;
+      }
+    } catch (e) {
+      console.error(`Error in gulp screenshots -> starting puppeteer: ${e}`);
     }
 
     const page = file.data && file.data.page;
@@ -73,10 +106,10 @@ module.exports = options => {
       return;
     }
 
-    const { port } = server.address();
-    const baseUrl = `http://127.0.0.1:${port}`;
-
     try {
+      const { port } = server.address();
+      const baseUrl = `http://127.0.0.1:${port}`;
+
       const image = await capture({
         file,
         baseUrl,
@@ -90,10 +123,11 @@ module.exports = options => {
       cb();
 
     } catch (e) {
-      console.error(`Error in gulpScreenshots: ${e}`);
+      console.error(`Error in gulp screenshots -> capture: ${e}`);
     }
   });
 
+  // https://nodejs.org/api/stream.html#stream_event_finish
   stream.on('finish', async () => {
     await browser.close();
     await server.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -917,11 +917,6 @@
         "@types/node": "*"
       }
     },
-    "@types/mime-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
-      "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM="
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -931,14 +926,22 @@
     "@types/node": {
       "version": "13.7.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
-      "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==",
-      "dev": true
+      "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
+    },
+    "@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@upstatement/eslint-config": {
       "version": "0.4.2",
@@ -968,9 +971,12 @@
       "dev": true
     },
     "agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "aggregate-error": {
       "version": "3.0.1",
@@ -1130,11 +1136,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
-    },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "ava": {
       "version": "3.5.0",
@@ -1377,11 +1378,26 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "blueimp-md5": {
       "version": "2.12.0",
@@ -1517,6 +1533,15 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-crc32": {
@@ -1686,6 +1711,11 @@
           "dev": true
         }
       }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chunkd": {
       "version": "2.0.1",
@@ -2265,6 +2295,11 @@
         }
       }
     },
+    "devtools-protocol": {
+      "version": "0.0.854822",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.854822.tgz",
+      "integrity": "sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg=="
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2598,68 +2633,31 @@
       }
     },
     "extract-zip": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "requires": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "concat-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
+            "pump": "^3.0.0"
           }
         },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -2787,7 +2785,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -2797,7 +2794,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -2806,7 +2802,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -2962,6 +2957,11 @@
       "requires": {
         "js-yaml": "^3.13.1"
       }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
@@ -3264,11 +3264,11 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "agent-base": "5",
+        "agent-base": "6",
         "debug": "4"
       }
     },
@@ -3280,6 +3280,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -4256,24 +4261,6 @@
         "picomatch": "^2.0.5"
       }
     },
-    "mime": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
-    },
-    "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
-    },
-    "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-      "requires": {
-        "mime-db": "1.43.0"
-      }
-    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -4297,7 +4284,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "mississippi": {
       "version": "4.0.0",
@@ -4356,6 +4344,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4378,6 +4371,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-preload": {
       "version": "0.2.1",
@@ -4737,7 +4735,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
       "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -4763,8 +4760,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-hash": {
       "version": "4.0.0",
@@ -4865,8 +4861,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -4943,7 +4938,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
       "requires": {
         "find-up": "^4.0.0"
       }
@@ -5043,20 +5037,32 @@
       }
     },
     "puppeteer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.1.1.tgz",
-      "integrity": "sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-8.0.0.tgz",
+      "integrity": "sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==",
       "requires": {
-        "@types/mime-types": "^2.1.0",
         "debug": "^4.1.0",
-        "extract-zip": "^1.6.6",
-        "https-proxy-agent": "^4.0.0",
-        "mime": "^2.0.3",
-        "mime-types": "^2.1.25",
+        "devtools-protocol": "0.0.854822",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "ws": "^6.1.0"
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "range-parser": {
@@ -5321,6 +5327,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -5733,6 +5740,40 @@
         }
       }
     },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -5765,8 +5806,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "3.0.1",
@@ -5949,6 +5989,15 @@
       "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "unc-path-regex": {
@@ -6363,12 +6412,9 @@
       }
     },
     "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "js-yaml": "^3.13.1",
     "lodash.defaultsdeep": "^4.6.1",
     "mississippi": "^4.0.0",
-    "puppeteer": "^2.1.1",
+    "puppeteer": "^8.0.0",
     "serve-handler": "^6.1.2",
     "through2": "^3.0.1",
     "vinyl": "^2.2.0",


### PR DESCRIPTION
## Changes

- Updates [puppeteer](https://pptr.dev/) to latest version (8.0.0)
- Refactors some of the gulp screenshots code to start the server & browser only once to cut down on build times

## Steps to test

- Pull down this branch, `npm install`, then run `npm link`
- In another terminal tab, clone & install the [Vanderbilt repo](https://github.com/Upstatement/vanderbilt-design-system).
- Checkout the branch for [this PR](https://github.com/Upstatement/vanderbilt-design-system/pull/223)
- `npm link @upstatement/puppy`
- `npm start` and make sure there are no errors and the thumbnails show up on the homepage

## To do

- [x] Add comments